### PR TITLE
パンくずリスト用のレイアウトを作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,4 @@ gem "omniauth-rails_csrf_protection"
 gem 'omniauth-google-oauth2'
 gem 'omniauth-facebook'
 gem 'ancestry'
+gem 'gretel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -369,6 +371,7 @@ DEPENDENCIES
   fog-aws
   font-awesome-rails
   font-awesome-sass (~> 5.11.2)
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@
 @import 'modules/slick-theme';
 @import 'modules/sellbutton';
 @import 'modules/header';
+@import 'modules/breadcrumb';
 @import 'modules/footer';
 @import 'modules/footertop';
 @import 'modules/header_login';
@@ -31,6 +32,7 @@ body {
   font-size: 14px;
   color: #333;
   line-height: 1;
+  overflow-x: hidden;
 }
 
 * {

--- a/app/assets/stylesheets/config/_variable.scss
+++ b/app/assets/stylesheets/config/_variable.scss
@@ -9,3 +9,7 @@ $m-margin: (
   headerTop: 40px,
   side: 40px,
 );
+
+$r-margin: (
+  side: 80px,
+);

--- a/app/assets/stylesheets/layouts/_card.scss
+++ b/app/assets/stylesheets/layouts/_card.scss
@@ -1,9 +1,8 @@
 .card {
   display: flex;
-  margin: map-get($m-margin, headerTop) auto 0;
   .container {
     display: flex;
-    margin: 0 auto;
+    margin: map-get($m-margin, headerTop) auto 0;
     overflow: hidden;
     @include media('tb') {
       width: 100%;
@@ -17,15 +16,10 @@
       margin-bottom: auto;
       order: 1;
       @include media('tb') {
-        width: calc(
-          100% - #{map-get($m-width, side)} - #{map-get($m-margin, side)}
-        );
-        margin: 0 auto;
+        width: map-get($m-width, contents);
       }
       @include media('sp') {
-        width: calc(100% - #{map-get($m-margin, side)});
-        margin: 0 auto;
-        float: none;
+        width: 100%;
       }
     }
     .title {

--- a/app/assets/stylesheets/layouts/_mypage.scss
+++ b/app/assets/stylesheets/layouts/_mypage.scss
@@ -5,6 +5,10 @@
   background-color: #f5f5f5;
   margin: map-get($m-margin, headerTop) auto 0;
   width: 1020px;
+  @include media('tb') {
+    width: 100%;
+    display: block;
+  }
 }
 
 .mypage-side {
@@ -13,11 +17,13 @@
   margin-right: map-get($m-margin, side);
   color: #333;
   z-index: 1;
-  @include media('sp') {
-    width: calc(100% - #{map-get($m-margin, side)});
-    margin: 0 auto;
+  @include media('tb') {
+    width: map-get($m-width, contents);
     margin-top: map-get($m-margin, side);
-    float: none;
+  }
+  @include media('sp') {
+    width: 100%;
+    margin-top: map-get($m-margin, side);
   }
   &--nav__list {
     margin-bottom: 40px;
@@ -25,7 +31,6 @@
       border-top: 1px solid #eee;
       position: relative;
       display: block;
-
       padding: 16px;
       background-color: #fff;
       font-size: 14px;
@@ -49,7 +54,7 @@
       .fa {
         position: absolute;
         top: 50%;
-        right: 16%;
+        right: 5%;
         transform: translate(0, -50%);
         color: #ccc;
       }
@@ -57,7 +62,9 @@
   }
 }
 .mypage-side--nav__head {
+  font-size: 16px;
   font-weight: bold;
+  padding-bottom: 5px;
 }
 
 .user {
@@ -98,7 +105,7 @@
         font-size: 14px;
       }
       .mypage-number {
-        margin: 8px 0 0;
+        margin: 15px 0 0;
         font-size: 16px;
       }
     }
@@ -106,7 +113,9 @@
 
   .mypage__content {
     margin: 0;
-    background: #fff;
+    @include media('tb') {
+      width: map-get($m-width, contents);
+    }
     .mypage__content--tabs {
       border: 0;
       background-color: #eee;
@@ -123,7 +132,6 @@
           background-color: #fff;
           border-top: 2px solid #ea352d;
         }
-
         h3 {
           font-size: 16px;
           line-height: 72px;
@@ -147,7 +155,6 @@
       height: 81px;
       border-bottom: 1px solid #eee;
       position: relative;
-
       .tab__content__item--link {
         display: block;
         height: 64px;
@@ -180,7 +187,7 @@
       }
 
       .mypage-go {
-        padding: 16px;
+        padding: 10px;
         &--list {
           text-decoration: none;
           display: block;
@@ -197,7 +204,7 @@
   .mypage__buy {
     margin: 40px 0 0;
     background: #fff;
-
+    font-weight: bold;
     &__head {
       padding: 0 16px;
       background: #fafafa;
@@ -207,7 +214,6 @@
     &__tabs {
       background: #eee;
       display: flex;
-
       li {
         background: #eee;
         width: 50%;
@@ -230,12 +236,16 @@
     &__foot {
       margin: 0;
       padding: 0;
-      &--not-found {
-        padding: 160px 0 60px;
-        background: url(/jp/assets/img/common/common/logo-gray-icon.svg?7989621);
+      &--not-img {
+        padding: 160px 0 0;
+        background-image: image-url('logo_red.svg');
+        opacity: 0.1;
         background-repeat: no-repeat;
         background-position: center 40px;
         background-size: 78px 85px;
+      }
+      &--not-found {
+        padding: 10px 0 60px;
         text-align: center;
         font-size: 16px;
         color: #ccc;

--- a/app/assets/stylesheets/layouts/_profile.scss
+++ b/app/assets/stylesheets/layouts/_profile.scss
@@ -1,9 +1,8 @@
 .profile {
   display: flex;
-  margin: map-get($m-margin, headerTop) auto 0;
   .container {
     display: flex;
-    margin: 0 auto;
+    margin: map-get($m-margin, headerTop) auto 0;
     overflow: hidden;
     @include media('tb') {
       width: 100%;
@@ -17,15 +16,10 @@
       margin-bottom: auto;
       order: 1;
       @include media('tb') {
-        width: calc(
-          100% - #{map-get($m-width, side)} - #{map-get($m-margin, side)}
-        );
-        margin: 0 auto;
+        width: map-get($m-width, contents);
       }
       @include media('sp') {
-        width: calc(100% - #{map-get($m-margin, side)});
-        margin: 0 auto;
-        float: none;
+        width: 100%;
       }
     }
     .title {

--- a/app/assets/stylesheets/mixins/_media.scss
+++ b/app/assets/stylesheets/mixins/_media.scss
@@ -1,10 +1,12 @@
 $breakpoint: (
   sp: 'only screen and (max-width: 767px)',
-  tb: 'only screen and (max-width: 1024px)',
+  tb: 'only screen and (max-width: 1060px)',
 );
 
 @mixin media($device) {
   @media #{map-get($breakpoint, $device)} {
+    margin: 10px auto 0;
+    float: none;
     @content;
   }
 }

--- a/app/assets/stylesheets/mixins/_mixin.scss
+++ b/app/assets/stylesheets/mixins/_mixin.scss
@@ -98,11 +98,8 @@
       weight: bold;
     }
     @include media('sp') {
-      width: calc(100% - #{map-get($m-margin, side)});
-      font: {
-        size: 18px;
-      }
-      padding: 1.5%;
+      font-size: 18px;
+      line-height: 1;
     }
     text-align: center;
     line-height: 1.4;
@@ -240,7 +237,7 @@
 @mixin balloon() {
   position: absolute;
   display: none;
-  top: 28.5%;
+  top: 30.3%;
   left: 49.2%;
   width: 345px;
   z-index: 1;
@@ -254,24 +251,18 @@
     width: 0;
     height: 0;
     position: absolute;
-    top: -10px;
-    left: 300px;
+    top: -8%;
+    left: 80%;
     border-style: solid;
     border-width: 0 10px 15px 10px;
     border-color: transparent transparent #e4e3e3 transparent;
   }
   @include media('tb') {
-    width: calc(
-      100% - #{map-get($m-width, side)} - #{map-get($m-margin, side)}
-    );
-    width: 345px;
-    top: 28.5%;
-    left: 48.5%;
+    top: 22.8%;
+    left: 33.8%;
   }
   @include media('sp') {
-    width: calc(100% - #{map-get($m-margin, side)});
-    width: 345px;
-    top: 21.5%;
-    left: 15%;
+    top: 23.7%;
+    left: 24.6%;
   }
 }

--- a/app/assets/stylesheets/modules/_breadcrumb.scss
+++ b/app/assets/stylesheets/modules/_breadcrumb.scss
@@ -1,0 +1,22 @@
+.breadcrumb {
+  background-color: #fff;
+  box-shadow: #0000002e 0px 2px 4px;
+  position: relative;
+  nav {
+    width: 1020px;
+    margin: 0 auto;
+    padding: 15px 10px;
+    height: 45px;
+    @include media('tb') {
+      width: map-get($m-width, contents);
+      margin: 0 auto;
+    }
+    @include media('sp') {
+      width: 100%;
+      margin: 0 10px 0;
+    }
+  }
+  a {
+    @include linkText($color: #333, $ocd: 1, $och: 0.5);
+  }
+}

--- a/app/assets/stylesheets/modules/_footer.scss
+++ b/app/assets/stylesheets/modules/_footer.scss
@@ -94,6 +94,10 @@
     }
     .logo {
       filter: invert(100%);
+      a:hover {
+        opacity: 0.7;
+        transition: all ease-out 0.3s;
+      }
     }
     .corporatemark {
       width: calc(1020px - 745px);

--- a/app/assets/stylesheets/modules/_header.scss
+++ b/app/assets/stylesheets/modules/_header.scss
@@ -1,100 +1,121 @@
-.main-header{
+.main-header {
   background-color: #fff;
   height: 100px;
   font-weight: 500;
   position: relative;
   font-family: Arial, 游ゴシック体, YuGothic, メイリオ, Meiryo, sans-serif;
-  box-shadow: 0 3px 3px 0 rgba(0,0,0,0.16);
+  box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.16);
 }
 
-.header-inner{
+.header-inner {
   max-width: 1020px;
   margin: 0 auto;
-  padding: 8px 0 0;
 }
 
-.inner-top{
+.inner-top {
+  width: 100%;
   max-width: 1020px;
   height: 40px;
   display: flex;
   justify-content: space-between;
-  &__logo{
+  padding-top: 8px;
+  @include media('tb') {
+    width: map-get($m-width, contents);
+    padding-top: 0;
+  }
+  @include media('sp') {
+    width: 100%;
+    padding: 0 10px;
+  }
+  &__logo {
     display: flex;
     height: 40px;
     margin-right: 45px;
   }
-  &__form{
-    width:100%;
+  &__form {
+    width: 100%;
     position: relative;
   }
 }
 
-.search-form{
+.search-form {
   position: relative;
   height: 40px;
   width: 100%;
+  background-color: #f5f5f5;
   border-radius: 4px;
   border: 1px solid #ccc;
+  margin-right: 10px;
   padding: 0px 50px 0px 10px;
-  &__icon{
+  &:focus {
+    @include form-focus;
+  }
+  &__icon {
     position: absolute;
     right: 0;
     top: 0;
     height: 40px;
     width: 40px;
     padding: 0px;
-    background:none;
+    background: none;
     cursor: pointer;
   }
 }
 
-.inner-lwr{
+.inner-lwr {
   display: flex;
   justify-content: space-between;
-  margin-top: 8px;
+  margin-top: 15px;
+  @include media('tb') {
+    width: map-get($m-width, contents);
+  }
+  @include media('sp') {
+    width: 100%;
+    padding: 0 10px;
+  }
 }
 
-.lwr-menu{
+.lwr-menu {
   display: flex;
   float: left;
-  &__category{
+  &__category {
     cursor: pointer;
     height: 44px;
     position: relative;
     padding: 0px 10px;
   }
-  &__category:hover .category-list{
+  &__category:hover .category-list {
     display: block;
     z-index: 3;
   }
 
-  &__category:hover span{
+  &__category:hover span {
     color: #0099e8;
   }
 
-  &__brand{
+  &__brand {
     cursor: pointer;
     height: 44px;
     position: relative;
     padding: 0px 10px;
   }
 }
-.category-list{
+.category-list {
   display: none;
   position: absolute;
   top: 44px;
   left: 0;
   color: #333;
-  &__parent{
-    background-color:#fff;
+  &__parent {
+    background-color: #fff;
     box-shadow: rgba(0, 0, 0, 0.18) 0px 2px 4px;
     width: 200px;
   }
 }
 
-.list-parent{
+.list-parent {
   width: 200px;
-  &__child{
+  &__child {
     display: none;
     position: absolute;
     left: 200px;
@@ -104,13 +125,13 @@
     box-shadow: rgba(0, 0, 0, 0.18) 0px 2px 4px;
     width: 200px;
   }
-  .child-name{
+  .child-name {
     display: block;
     padding: 8px 16px;
-    }
+  }
 }
 
-.parent-name{
+.parent-name {
   display: block;
   font-size: 14px;
   line-height: 44px;
@@ -119,16 +140,16 @@
   overflow: hidden;
   padding: 0px 16px;
 }
-.list-parent:hover .list-parent__child{
+.list-parent:hover .list-parent__child {
   display: block;
 }
-.list-parent:hover .parent-name{
+.list-parent:hover .parent-name {
   background-color: #ea362d;
   color: #fff;
 }
-.list-child{
+.list-child {
   width: 200px;
-  &__son{
+  &__son {
     display: none;
     position: absolute;
     left: 200px;
@@ -138,34 +159,31 @@
     box-shadow: rgba(0, 0, 0, 0.18) 0px 2px 4px;
     width: 300px;
   }
-  .son-name{
+  .son-name {
     display: block;
     padding: 8px 16px;
-    }
+  }
 }
-.list-child:hover .list-child__son{
+.list-child:hover .list-child__son {
   display: block;
 }
 
-.list-child:hover .child-name{
+.list-child:hover .child-name {
   background-color: #ccc;
 }
 
-.list-son:hover{
+.list-son:hover {
   background-color: #ccc;
   z-index: 100;
 }
 
-
-
-
-.menu{
+.menu {
   display: block;
   font-size: 14px;
   font-weight: 600;
   line-height: 36px;
   white-space: nowrap;
-  i{
+  i {
     max-width: 100%;
     max-height: 100%;
     color: #ea362d;
@@ -174,36 +192,55 @@
   }
 }
 
-.fa-search{
+.fa-search {
   height: 14px;
   width: 14px;
   margin-top: 2px;
 }
 
-
-.lwr-user{
+.lwr-user {
   display: flex;
-  &__new{
+  &__new {
     text-align: center;
   }
-  &__login{
+  &__login {
     text-align: center;
     margin-left: 11px;
   }
-  &__like,&__notice,&__todo,&__mypage{
+  &__like,
+  &__notice,
+  &__todo,
+  &__mypage {
     padding: 0px 14px;
     display: block;
+    a {
+      &:hover {
+        color: #0099e8;
+        text-decoration: none;
+      }
+    }
+  }
+  &__like {
+    @include media('tb') {
+      display: none;
+    }
+  }
+  &__like,
+  &__todo {
+    @include media('sp') {
+      display: none;
+    }
   }
 }
 
-.icon-header{
+.icon-header {
   align-items: center;
   display: flex;
   font-size: 14px;
   height: 32px;
 }
 
-.user-new{
+.user-new {
   display: block;
   font-size: 14px;
   padding: 8px 10px;
@@ -215,7 +252,7 @@
   border-image: initial;
   border-radius: 4px;
 }
-.user-login{
+.user-login {
   display: block;
   font-size: 14px;
   padding: 8px 10px;
@@ -228,22 +265,22 @@
   border-radius: 4px;
 }
 
-a{
+a {
   text-decoration: none;
   color: #333;
 }
 
-.login-menu{
+.login-menu {
   display: block;
   font-size: 14px;
   line-height: 36px;
   white-space: nowrap;
-  i{
+  i {
     max-width: 100%;
     height: auto;
     max-height: 100%;
     color: rgb(204, 204, 204);
     margin-right: 10px;
-    width: 19px;
+    width: 13px;
   }
 }

--- a/app/assets/stylesheets/modules/_sellbutton.scss
+++ b/app/assets/stylesheets/modules/_sellbutton.scss
@@ -9,8 +9,8 @@
   z-index: 100;
   @include media('sp') {
     font-size: 15px;
-    bottom: -90px;
-    right: -90px;
+    bottom: -80px;
+    right: -50px;
   }
   &__main {
     background-color: rgb(234, 53, 45);

--- a/app/views/shared/_breadcrumb.html.haml
+++ b/app/views/shared/_breadcrumb.html.haml
@@ -1,0 +1,3 @@
+.breadcrumb
+  %nav
+    = breadcrumbs separator: "&emsp;&emsp;#{content_tag(:i, '', :class=>'fa fa-angle-right')}&emsp;&emsp;"

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -58,6 +58,7 @@
           %li.list United States
   .bottombox
     .logo
-      =image_tag "fmarket_logo_red.svg", size: '180x60', class: 'logo-a'
+      = link_to root_path do
+        =image_tag "fmarket_logo_red.svg", size: '180x60', class: 'logo-a'
     .corporatemark
       %li.acorporatemark © 2019 Fmarket

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -2,10 +2,10 @@
   .header-inner
     .inner-top
       .inner-top__logo
-        =link_to "#" do
+        = link_to root_path do
           = image_tag "fmarket_logo_red.svg", alt: 'logo', height: '36', width: '134', class: 'header-inner__top__logo'
       %form{action:"/", method:"post", class: "inner-top__form"}
-        %input{type:"search", placeholder:"何かお探しですか",class:"search-form"}
+        %input{type:"search", placeholder:"何かお探しですか？",class:"search-form"}
         %button{type:"submit", class:"search-form__icon"}
           = icon('fas','search',class:'icon')
     .inner-lwr
@@ -153,7 +153,7 @@
           .lwr-user__like
             =link_to"",class:"login-menu" do
               =icon('far', 'heart',class:"icon-header")
-              %span いいね一覧
+              %span いいね！一覧
           .lwr-user__notice
             =link_to"",class:"login-menu" do
               =icon('far', 'bell',class:"icon-header")
@@ -169,7 +169,9 @@
         - else
           .lwr-user__new
             =link_to new_user_registration_path, class:"user-new btn-red" do
-              新規登録
+              新規会員登録
           .lwr-user__login
             =link_to new_user_session_path, class:"user-login" do
               ログイン
+  .header-navi
+    - breadcrumb :users, :cards

--- a/app/views/shared/_mypage_main.html.haml
+++ b/app/views/shared/_mypage_main.html.haml
@@ -3,13 +3,10 @@
     =link_to "/" do
       %figure
         = image_tag 'icon.png'
-         
-          
       %h2.bold
         =current_user.nickname
       .mypage-number
         評価 20 出品数 31
-
   %section.mypage__content
     %ul.mypage__content--tabs
       %li.active.mypage__content--tab
@@ -43,7 +40,7 @@
             .tab__content__item--body
               %p
                 通知はありません
-              %i.fa.fa-angle-right           
+              %i.fa.fa-angle-right                   
         %li
           =link_to "#",class: 'tab__content__item--link' do
             %figure
@@ -51,20 +48,7 @@
             .tab__content__item--body
               %p
                 通知はありません
-
-
-              %i.fa.fa-angle-right          
-
-        %li
-          =link_to "#",class: 'tab__content__item--link' do
-            %figure
-              =image_tag  ("logo_red.svg")
-            .tab__content__item--body
-              %p
-                通知はありません
-
               %i.fa.fa-angle-right                 
-
         %li.li-go
           .mypage-go 
             =link_to "#" ,class: "mypage-go--list"do
@@ -81,5 +65,6 @@
             過去の取引
       .mypage__buy__foot
         %ul
+          %li.mypage__buy__foot--not-img
           %li.mypage__buy__foot--not-found
             取引中の商品がありません

--- a/app/views/shared/_mypage_side.html.haml
+++ b/app/views/shared/_mypage_side.html.haml
@@ -2,7 +2,7 @@
   .mypage-side--nav
     %ul.mypage-side--nav__list
       %li
-        =link_to "#", class: "mypage-side--nav__list__item active"  do
+        =link_to users_path ,class: "mypage-side--nav__list__item active" do
           マイページ
           %i.fa.fa-angle-right
       %li
@@ -18,7 +18,7 @@
           いいね！一覧
           %i.fa.fa-angle-right
       %li
-        =link_to "#" , class: "mypage-side--nav__list__item" do
+        =link_to freemarket_create_path ,class: "mypage-side--nav__list__item" do
           出品する
           %i.fa.fa-angle-right
       %li
@@ -72,7 +72,7 @@
       設定
     %ul.mypage-side--nav__list
       %li
-        =link_to "../users/profile"  ,class: "mypage-side--nav__list__item" do
+        =link_to users_profile_path ,class: "mypage-side--nav__list__item" do
           プロフィール
           %i.fa.fa-angle-right
       %li
@@ -80,7 +80,7 @@
           発送元・お届け先住所変更
           %i.fa.fa-angle-right
       %li
-        =link_to "../users/card"  ,class: "mypage-side--nav__list__item" do
+        =link_to users_card_path ,class: "mypage-side--nav__list__item" do
           支払い方法
           %i.fa.fa-angle-right
       %li

--- a/app/views/shared/_sellbutton.html.haml
+++ b/app/views/shared/_sellbutton.html.haml
@@ -1,6 +1,6 @@
 .toppage-button
   .toppage-button__main
-    = link_to('#', class:"toppage-button__main-link") do
+    = link_to freemarket_create_path, class:"toppage-button__main-link" do
       .toppage-button__main-up
         %p
         出品

--- a/app/views/users/card.html.haml
+++ b/app/views/users/card.html.haml
@@ -9,8 +9,9 @@
       .list-add
         %section.list-add__card
           %h3.sub-title クレジットカード一覧
-          %button{type:'submit', class:'list-add__card--btn'}
-            %span= link_to 'クレジットカードを追加する','../cards/create'
+          .list-add__card--btn
+            = link_to cards_create_path do
+              %span クレジットカードを追加する
         .list-add__border
         .list-add__payment-link
           %span=link_to '支払い方法について','#'

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,10 +1,13 @@
+- breadcrumb :users
 .header
-  =render "shared/header"
-.nav
+  = render "shared/header"
+  = render 'shared/breadcrumb'
 .main
   =render "shared/mypage_side"
   =render "shared/mypage_main"
+.nav
+  = render 'shared/sellbutton'
 .footer-top
   = render 'shared/footertop'
-.footer-top
+.footer
   = render 'shared/footer'

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,8 @@
+crumb :root do
+  link 'Fmarket', root_path
+end
+
+crumb :users do
+  link 'マイページ', users_path
+  parent :root
+end


### PR DESCRIPTION
# What
- パンくずリスト用のレイアウトを作成
- それに伴うレスポンシブやレイアウト崩れの修正
- 完成済みページのリンク貼り

# Why
- 前回のスプリントレビューでマイページマークアップのレイアウトにパンくずがないと指摘されていた為。

# Description
- 一応gem入れてますが、マイページまでしか設定できていませんのでほぼ飾りです。カテゴリ機能実装するのであれば、その関係性で見直しが必要かもしれません。
https://github.com/WilHall/gretel